### PR TITLE
Improve release event types

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -348,7 +348,7 @@ export interface ReleaseBase extends EntityBase {
   date?: IsoDate; // null?
   country?: IsoCountryCode | null;
   /** Release dates and areas. */
-  "release-events": ReleaseEvent[]; // null?
+  "release-events"?: ReleaseEvent[];
   /** Barcode of the release, can be empty (no barcode) or `null` (unset). */
   barcode: string | null;
   packaging: ReleasePackaging | null;

--- a/api_types.ts
+++ b/api_types.ts
@@ -22,7 +22,7 @@ export type IsoLanguageCode = string;
 /** ISO (four letter) code of a script. */
 export type IsoScriptCode = string;
 
-/** ISO 8601 `YYYY-MM-DD` date, can be partial (`YYYY-MM-DD` or `YYYY`). */
+/** ISO 8601 `YYYY-MM-DD` date, can be partial (`YYYY-MM-DD` or `YYYY`) or empty. */
 export type IsoDate = string;
 
 /**
@@ -345,7 +345,7 @@ export interface ReleaseBase extends EntityBase {
   title: string;
   /** Disambiguation comment, can be empty. */
   disambiguation: string;
-  date?: IsoDate; // null?
+  date?: IsoDate;
   country?: IsoCountryCode | null;
   /** Release dates and areas. */
   "release-events"?: ReleaseEvent[];
@@ -487,8 +487,8 @@ export interface Track {
 }
 
 export interface ReleaseEvent {
-  date: IsoDate; // null?
-  area: MinimalArea | null; // null?
+  date: IsoDate;
+  area: MinimalArea | null;
 }
 
 export interface LabelInfo {

--- a/test/download_testdata.ts
+++ b/test/download_testdata.ts
@@ -50,6 +50,8 @@ export const lookupTestCases: Array<[EntityType, MBID, string[]?]> = [
     "tags",
     "genres",
   ]],
+  // Has no release-events.
+  ["release", "8693def6-3680-461d-9132-271400007a48"],
   ["recording", "a8ccb91b-1a09-49d9-b96a-4eb13bd5c0f7", [
     "artists",
     "releases",

--- a/test/download_testdata.ts
+++ b/test/download_testdata.ts
@@ -52,6 +52,8 @@ export const lookupTestCases: Array<[EntityType, MBID, string[]?]> = [
   ]],
   // Has no release-events.
   ["release", "8693def6-3680-461d-9132-271400007a48"],
+  // Has a release event with no date, and another with no country.
+  ["release", "065aa2d6-e38e-4caa-b883-ea2ebf2ddda8"],
   ["recording", "a8ccb91b-1a09-49d9-b96a-4eb13bd5c0f7", [
     "artists",
     "releases",


### PR DESCRIPTION
The only actual type change here is making `"release-events"` optional.

The rest of the changes are just clarifying that the `"date"` properties cannot be `null` (if they are, it's a bug), only `"area"`.