### PR TITLE
fix: Allow narrowing a `Relationship` by its `target-type` and a `Collection` by its `entity-type`

### DIFF
--- a/api_includes.ts
+++ b/api_includes.ts
@@ -80,7 +80,9 @@ type UnwrapData<Data, Include extends IncludeParameter> =
     // Each item of a data array has to be unwrapped individually (except primitives).
     : Data extends Array<infer Item>
     // Turn off distributivity to leave primitive union types alone.
-      ? [Item] extends [object] ? WithIncludes<Item, Include>[] : Data
+      ? [Item] extends [string | number | undefined] ? Item[]
+      : Item extends object ? WithIncludes<Item, Include>[]
+      : Item[]
     : Data extends object ? WithIncludes<Data, Include>
     // Leave primitive values alone, there is nothing to unwrap.
     : Data;

--- a/api_types.ts
+++ b/api_types.ts
@@ -487,51 +487,48 @@ export interface GenreTag extends GenreUserTag {
   count: number;
 }
 
-export type Relationship<
-  TargetType extends RelatableEntityType = RelatableEntityType,
-> =
-  & IfUnionType<
-    TargetType,
-    {
-      /** Target entity, only the key which matches the value of target type is present. */
-      [Key in TargetType as SnakeCase<Key>]?: MinimalEntityTypeMap[Key];
-    },
-    {
+export type RelationshipTypeMap = {
+  [TargetType in RelatableEntityType]:
+    & {
       /** Target entity. */
       [Key in TargetType as SnakeCase<Key>]: MinimalEntityTypeMap[Key];
     }
-  >
-  & {
-    /** Type of the target entity. */
-    "target-type": SnakeCase<TargetType>;
-    /** Name of the relationship type. */
-    type: string;
-    /** MBID of the relationship type. */
-    "type-id": MBID;
-    /**
-     * Direction of the relationship.
-     * Important if source and target entity have the same type.
-     */
-    direction: RelationshipDirection;
-    /** Order of the relationship if relationships of this type are orderable. */
-    "ordering-key"?: number;
-    /** Names of the relationship attributes. */
-    attributes: string[];
-    /** Maps attribute names to their optional value. */
-    "attribute-values": Record<string, string>;
-    /** Maps attribute names to their MBID. */
-    "attribute-ids": Record<string, MBID>;
-    /**
-     * Maps attribute names to their optional credited name.
-     * Only present if any of the attributes is creditable.
-     */
-    "attribute-credits"?: Record<string, string>;
-    /** Credited name of the source entity, can be empty. */
-    "source-credit": string;
-    /** Credited name of the target entity, can be empty. */
-    "target-credit": string;
-  }
-  & DatePeriod;
+    & {
+      /** Type of the target entity. */
+      "target-type": SnakeCase<TargetType>;
+      /** Name of the relationship type. */
+      type: string;
+      /** MBID of the relationship type. */
+      "type-id": MBID;
+      /**
+       * Direction of the relationship.
+       * Important if source and target entity have the same type.
+       */
+      direction: RelationshipDirection;
+      /** Order of the relationship if relationships of this type are orderable. */
+      "ordering-key"?: number;
+      /** Names of the relationship attributes. */
+      attributes: string[];
+      /** Maps attribute names to their optional value. */
+      "attribute-values": Record<string, string>;
+      /** Maps attribute names to their MBID. */
+      "attribute-ids": Record<string, MBID>;
+      /**
+       * Maps attribute names to their optional credited name.
+       * Only present if any of the attributes is creditable.
+       */
+      "attribute-credits"?: Record<string, string>;
+      /** Credited name of the source entity, can be empty. */
+      "source-credit": string;
+      /** Credited name of the target entity, can be empty. */
+      "target-credit": string;
+    }
+    & DatePeriod;
+};
+
+export type Relationship<
+  TargetType extends RelatableEntityType = RelatableEntityType,
+> = RelationshipTypeMap[TargetType];
 
 export type RelationshipDirection = "backward" | "forward";
 

--- a/api_types.ts
+++ b/api_types.ts
@@ -149,42 +149,37 @@ export interface Artist extends MinimalArtist, MiscSubQueries {
   works: SubQuery<MinimalWork[], "works">;
 }
 
-export type MinimalCollection<
-  ContentType extends CollectableEntityType = CollectableEntityType,
-> =
-  & {
-    id: MBID;
-    name: string;
-    editor: string;
-    type: string;
-    "type-id": MBID;
-    "entity-type": SnakeCase<ContentType>;
-  }
-  & IfUnionType<
-    ContentType,
-    {
-      [Key in `${ContentType}-count`]?: number;
-    },
-    {
+export type MinimalCollectionTypeMap = {
+  [ContentType in CollectableEntityType]:
+    & {
       [Key in `${ContentType}-count`]: number;
     }
-  >;
+    & {
+      id: MBID;
+      name: string;
+      editor: string;
+      type: string;
+      "type-id": MBID;
+      "entity-type": SnakeCase<ContentType>;
+    };
+};
 
-export type Collection<
+export type MinimalCollection<
   ContentType extends CollectableEntityType = CollectableEntityType,
-> =
-  & IfUnionType<
-    ContentType,
-    {
-      /** Collected entities, only the key which matches the value of entity type is present. */
-      [Key in ContentType as EntityPlural<Key>]?: MinimalEntityTypeMap[Key][];
-    },
-    {
+> = MinimalCollectionTypeMap[ContentType];
+
+export type CollectionTypeMap = {
+  [ContentType in CollectableEntityType]:
+    & {
       /** Collected entities. */
       [Key in ContentType as EntityPlural<Key>]: MinimalEntityTypeMap[Key][];
     }
-  >
-  & MinimalCollection<ContentType>;
+    & MinimalCollection<ContentType>;
+};
+
+export type Collection<
+  ContentType extends CollectableEntityType = CollectableEntityType,
+> = CollectionTypeMap[ContentType];
 
 export interface MinimalEvent extends MinimalEntity {
   time: string;
@@ -533,10 +528,6 @@ export type Relationship<
 export type RelationshipDirection = "backward" | "forward";
 
 export type RelInclude = `${RelatableEntityType}-rels`;
-
-type IfUnionType<T, True, False, U extends T = T> = T extends unknown
-  ? [U] extends [T] ? False : True
-  : False;
 
 // The above entity types should not be used without this utility type.
 // Reexport it here as long as there are no `EntityWith` type aliases for each entity type.


### PR DESCRIPTION
TypeScript has the concept of discriminating unions by a shared field name. For example:

```TypeScript
declare var relations: Relationship[];
for (const r of relations) {
  switch (r["target-type"]) {
    case "area":
      r.area.name;
      break;
    case "release_group":
      r.release_group.title;
      break;
  }
}
```

On the `main` branch, this currently errors:

    error: TS18048 [ERROR]: 'r.area' is possibly 'undefined'.
          r.area.name;
          ~~~~~~
        at file:///home/michael/code/musicbrainz-ts/test/data/lookup.ts:1180:7
   
    TS18048 [ERROR]: 'r.release_group' is possibly 'undefined'.
          r.release_group.title;
          ~~~~~~~~~~~~~~~
        at file:///home/michael/code/musicbrainz-ts/test/data/lookup.ts:1183:7
   
    Found 2 errors.

With the changes in this commit, the same code type-checks. (It also blocks you from accessing `r.release_group` under the `"area"` branch, or `r.area` under the `"release_group"` branch, etc.).

The only way I could get this to work was by partially re-enabling the distributivity that was disabled in 72e3ba55688793fc4e26d02d402b1763243a77fa; I kept it disabled for `string` and `number`, which I believe are the only two primitives *contained in arrays* we need to be concerned about.

@kellnerd If you agree to this patch (and it doesn't cause any issues I didn't anticipate), a similar patch could be applied to collections.