### PR TITLE
Unbreak `url-rels` and demonstrate unresolved issue with multiple "rels" `inc` parameters

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -110,7 +110,7 @@ export type MinimalEntityTypeMap = {
   "release-group": MinimalReleaseGroup;
   series: MinimalSeries;
   work: MinimalWork;
-  url: $Url;
+  url: MinimalUrl;
 };
 
 /** Entity with an MBID. */
@@ -512,12 +512,14 @@ export interface $Series<
   Include extends IncludeParameter = IncludeParameter,
 > extends MinimalSeries, WithAnnotation, WithRels<Include> {}
 
-export interface $Url<
-  Include extends IncludeParameter = IncludeParameter,
-> extends EntityWithMbid, WithRels<Include> {
+export interface MinimalUrl extends EntityWithMbid {
   /** Underlying URL. */
   resource: string;
 }
+
+export interface $Url<
+  Include extends IncludeParameter = IncludeParameter,
+> extends MinimalUrl, WithRels<Include> {};
 
 export interface MinimalWork extends MinimalEntity, WithType {
   /** Canonical title of the work, expressed in its original language. */

--- a/test/download_testdata.ts
+++ b/test/download_testdata.ts
@@ -81,6 +81,7 @@ export const lookupTestCases: LookupTestCase[] = [
   ]],
   ["area", "74e50e58-5deb-4b99-93a2-decbb365c07f", [
     "url-rels",
+    "area-rels",
   ]],
 ];
 

--- a/test/download_testdata.ts
+++ b/test/download_testdata.ts
@@ -79,6 +79,9 @@ export const lookupTestCases: LookupTestCase[] = [
     "releases",
     "discids",
   ]],
+  ["area", "74e50e58-5deb-4b99-93a2-decbb365c07f", [
+    "url-rels",
+  ]],
 ];
 
 export function convertApiUrlToTestCase(


### PR DESCRIPTION
Hi @kellnerd: while testing the library, I noticed that `url-rels` didn't work correctly, so I fixed that in the first commit and added a test case.

Then I tried appending `"area-rels"` to the exact same test case, and things broke again. :confused: In fact, I discovered that combining two or more "rels" `inc` parameters will break provided that the `"relations"` array actually contains relationships of those types. (This is why the existing release test case for `b50caad5-fe40-4c98-8947-f2a77ccc8a6c` doesn't fail: even though it specifies both `work-rels` and `release-group-rels`, the release itself does not have any *direct* relationships to works, only release groups.)

```
Task test-types deno check test/data/*.ts
Check file:///home/michael/code/musicbrainz-ts/test/data/lookup.ts
error: TS2322 [ERROR]: Type '({ attributes: never[]; type: string; ended: false; area: { type: string; "type-id": string; name: string; "iso-3166-2-codes": string[]; disambiguation: string; id: string; "sort-name": string; }; begin: null; ... 7 more ...; "target-type": "area"; } | { ...; } | { ...; })[]' is not assignable to type 'WithIncludes<{ area: MinimalArea; } & RelationshipBase<"area"> & DatePeriod, "area-rels" | "url-rels">[] | WithIncludes<{ ...; } & ... 1 more ... & DatePeriod, "area-rels" | "url-rels">[]'.
  Type '({ attributes: never[]; type: string; ended: false; area: { type: string; "type-id": string; name: string; "iso-3166-2-codes": string[]; disambiguation: string; id: string; "sort-name": string; }; begin: null; ... 7 more ...; "target-type": "area"; } | { ...; } | { ...; })[]' is not assignable to type 'WithIncludes<{ area: MinimalArea; } & RelationshipBase<"area"> & DatePeriod, "area-rels" | "url-rels">[]'.
    Type '{ attributes: never[]; type: string; ended: false; area: { type: string; "type-id": string; name: string; "iso-3166-2-codes": string[]; disambiguation: string; id: string; "sort-name": string; }; begin: null; ... 7 more ...; "target-type": "area"; } | { ...; } | { ...; }' is not assignable to type 'WithIncludes<{ area: MinimalArea; } & RelationshipBase<"area"> & DatePeriod, "area-rels" | "url-rels">'.
      Object literal may only specify known properties, and '"url"' does not exist in type 'WithIncludes<{ area: MinimalArea; } & RelationshipBase<"area"> & DatePeriod, "area-rels" | "url-rels">'.
      "url": {
      ~~~~~
    at file:///home/michael/code/musicbrainz-ts/test/data/lookup.ts:1374:7

    The expected type comes from property 'relations' which is declared here on type 'Area<"area-rels" | "url-rels">'
      relations: $SubQuery<
      ~~~~~~~~~
        at file:///home/michael/code/musicbrainz-ts/api_types.ts:183:3
```

Unfortunately, I couldn't determine how to fix this error. :disappointed: Either I'm missing something obvious, or it's another limitation of TypeScript's inference abilities. You likely have more insight than I do.