### PR TITLE
fix: Allow mixed relationship array assignments

### DIFF
--- a/api_includes.ts
+++ b/api_includes.ts
@@ -17,17 +17,19 @@ export type $SubQuery<Data, RequiredInclude extends IncludeParameter> = {
 };
 
 /**
- * {@linkcode Entity} with additional information for the given include parameters.
+ * {@linkcode Data} with additional information for the given include parameters.
  *
  * Recursively unwraps the data and removes unavailable properties.
  */
 export type WithIncludes<
-  Entity extends object,
+  Data,
   Include extends IncludeParameter,
-> = Pick<
-  UnwrapProperties<Entity, Include>,
-  AvailableKeys<Entity, Include>
->;
+> = Data extends object ? Pick<
+    UnwrapProperties<Data, Include>,
+    AvailableKeys<Data, Include>
+  >
+  // Leave primitive values alone, there is nothing to unwrap.
+  : Data;
 
 /**
  * Keys of all properties which are included in {@linkcode Entity} for the given
@@ -83,11 +85,8 @@ type UnwrapData<Data, Include extends IncludeParameter> =
     : Data extends Array<infer Item>
     // Turn off distributivity to leave primitive union types alone.
       ? [Item] extends [string | number | undefined] ? Item[]
-      : Item extends object ? WithIncludes<Item, Include>[]
-      : Item[]
-    : Data extends object ? WithIncludes<Data, Include>
-    // Leave primitive values alone, there is nothing to unwrap.
-    : Data;
+      : WithIncludes<Item, Include>[]
+    : WithIncludes<Data, Include>;
 
 /**
  * All possible include parameter values for the given {@linkcode Entity}.

--- a/test/download_testdata.ts
+++ b/test/download_testdata.ts
@@ -81,9 +81,7 @@ export const lookupTestCases: LookupTestCase[] = [
   ]],
   ["area", "74e50e58-5deb-4b99-93a2-decbb365c07f", [
     "url-rels",
-    // FIXME: Multiple rel target types within an array cause a type error with
-    // the current test setup, but this problem should not occur in practice.
-    // "area-rels",
+    "area-rels",
   ]],
 ];
 


### PR DESCRIPTION
Fixes the issue described in #4.

In `A extends any ? A[] : never`, if `A` is the union type `B | C`, then the conditional type will evaluate to `B[] | C[]`.

In order to produce `(B | C)[]`, the array syntax `[]` must be lifted out of the conditional type so that it's not distributed to each item in the union.

With respect to issue #4, we can achieve this by moving the problematic conditional type expression into `WithIncludes`, which now acts on an unknown `Data` type parameter:

 * If `Data` is an object, then `WithIncludes` behaves like before.
 * Otherwise, it now returns `Data` back.

----

I know these types can be finicky, so hopefully this patch doesn't cause any new unforeseen issues. I did make sure to test that refining relationships in a loop still works:

```TypeScript
const rels: MB.Area<"area-rels" | "url-rels">["relations"] = [];
for (const rel of rels) {
  if (rel["target-type"] == "area") console.log(rel.area);
  else console.log(rel.url);
}
```